### PR TITLE
Made pulling settings recursive

### DIFF
--- a/Util/ParseSettings.ahk
+++ b/Util/ParseSettings.ahk
@@ -1,9 +1,46 @@
-FileRead, ini, %A_ScriptDir%\Settings.ini
+; Referenced from https://www.autohotkey.com/boards/viewtopic.php?p=221966#p221966
+; Original Creator @jeeswg 
 
-Settings := []
+vPath := A_ScriptDir "\Settings.ini"
+FileRead, vText, % vPath
+vArray := vArrayLast := ""
+Loop, Parse, vText, `n, `r
+{
+	vTemp := A_LoopField
+	if (vTemp ~= "^\[.*]$") ;a section header is detected
+	{
+		;show info for the previous section
+		if !(vArray = "")
+		{
+			vOutput := ""
+			for vKey, vValue in %vArray%
+				vOutput .= vKey " " vValue "`r`n"
+			MsgBox, % vArray "`r`n`r`n" vOutput
+		}
+		vArrayLast := vArray
+		vSection := SubStr(vTemp, 2, -1)
+		; MsgBox, % vSection
+		vArray := vSection
+		%vArray% := {} ;create an array with section header
+		continue
+	}
+	;note: StrSplit MaxParts requires v1.1.28+
+	oTemp := StrSplit(A_LoopField, "=",, 2)
+	if !(oTemp.Length() = 2)
+	|| (vArray = "")
+		continue
+	; MsgBox, % vArray "." oTemp.1 "=" oTemp.2
+    if (oTemp.1 = "ScriptName" and oTemp.2 = "") ; added failover for if ScriptName is not provided
+        %vArray%[oTemp.1] := A_ScriptName
+    else
+	    %vArray%[oTemp.1] := oTemp.2
+}
 
-; Probably inefficient
-Settings.ScriptName := (ini_getValue(ini, "Settings", "ScriptName") = "") ? A_ScriptName : ini_getValue(ini, "Settings", "ScriptName")
-Settings.StartupNotification := ini_getValue(ini, "Settings", "StartupNotification")
-Settings.UseAutoCorrect := ini_getValue(ini, "Settings", "UseAutoCorrect")
-Settings.EditorPath := ini_getValue(ini, "Settings", "EditorPath")
+;show info for the previous section
+if !(vArrayLast = "")
+{
+	vOutput := ""
+	for vKey, vValue in %vArray%
+		vOutput .= vKey " " vValue "`r`n"
+	MsgBox, % vArray "`r`n`r`n" vOutput
+}


### PR DESCRIPTION
I liked your template and I saw that the setting parser was hardcoded. 
I pulled some code I saw online and adjusted it to match what was being done previously and made it recursive so additional settings would automatically be available without needing to hardcode them in the parser. 